### PR TITLE
fix: codeowners change filter

### DIFF
--- a/.github/workflows/codeowners-validation.yaml
+++ b/.github/workflows/codeowners-validation.yaml
@@ -2,19 +2,35 @@ name: "CodeOwners Validation"
 
 on:
   pull_request:
-    paths:
-      - ".github/CODEOWNERS"
-      - "CODEOWNERS"
+    # Path filtering doesn't work on org-wide rulesets
+    # paths:
+    #   - ".github/CODEOWNERS"
+    #   - "CODEOWNERS"
 
 jobs:
-  validate-codeowners:
-    name: "Validate"
+  filter-changes:
+    name: Filter Changes for CodeOwners
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      pull-requests: read
     steps:
-      # Checks-out your repository, which is validated in the next step
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            codeowners:
+              - ".github/CODEOWNERS"
+              - "CODEOWNERS"
+
+  validate-codeowners:
+    name: "Validate"
+    runs-on: ubuntu-latest
+    needs: filter-changes
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ needs.filter-changes.outputs.codeowners == 'true' }}
+    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
@@ -26,11 +42,10 @@ jobs:
         with:
           aws-role-arn: ${{ secrets.GATI_CODEOWNERS_IAM_ARN }}
           aws-lambda-url: ${{ secrets.GATI_CODEOWNERS_LAMBDA_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: "us-west-2"
 
       - name: GitHub CODEOWNERS Validator
         uses: patrickhuie19/codeowners-validator@176f0bfd300c754c6cc8d4a9e9863323e6752b90 # v0.1.8
-        # input parameters
         with:
           github_access_token: ${{ steps.gh-token.outputs.access-token }}
           repository_path: ${{ github.workspace }}

--- a/.github/workflows/codeowners-validation.yaml
+++ b/.github/workflows/codeowners-validation.yaml
@@ -2,12 +2,11 @@ name: "CodeOwners Validation"
 
 on:
   pull_request:
-    # Path filtering doesn't work on org-wide rulesets
-    # paths:
-    #   - ".github/CODEOWNERS"
-    #   - "CODEOWNERS"
 
 jobs:
+  # This job is necessary because the org-wide rulesets don't support event-based path filtering.
+  # (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-based-on-files-changed-in-a-pull-request)
+  # We include this job to filter the paths manually.
   filter-changes:
     name: Filter changes
     runs-on: ubuntu-latest

--- a/.github/workflows/codeowners-validation.yaml
+++ b/.github/workflows/codeowners-validation.yaml
@@ -9,13 +9,16 @@ on:
 
 jobs:
   filter-changes:
-    name: Filter Changes for CodeOwners
+    name: Filter changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      codeowners: ${{ steps.filter.outputs.codeowners }}
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
         with:
           filters: |
             codeowners:


### PR DESCRIPTION
### Changes

The org-wide ruleset runs the workflow and doesn't take into account changed paths like regular workflows.

Add a paths filtering job to skip running the validator if the paths have not been changed.

### Testing

Tested with an org-wide ruleset applied to the .github repository only.

No codeowners change:
- https://github.com/smartcontractkit/.github/actions/runs/13796935740?pr=909

codeowners change:
- https://github.com/smartcontractkit/.github/actions/runs/13796904442?pr=909

---

DX-23